### PR TITLE
added section for uploading house documents (contracts, rules, etc.)

### DIFF
--- a/client/src/components/CPListings/CPHomeSurvey/Step6.js
+++ b/client/src/components/CPListings/CPHomeSurvey/Step6.js
@@ -5,9 +5,9 @@ import FileUpload from '../FileUpload';
 
 export default function Step6({ listingInfo, setListingInfo }) {
   const folderPath = `users/${listingInfo.LicenseNumber}`;
-	const handleNewPics = (arrNewFilePaths) => {
+	const handleNewPics = (arrNewFiles) => {
 		let petPics = listingInfo?.petPics ?? [];
-    petPics.push(...arrNewFilePaths); 
+    petPics.push(...arrNewFiles); 
     setListingInfo({...listingInfo, petPics: petPics});
 	}
 
@@ -18,9 +18,9 @@ export default function Step6({ listingInfo, setListingInfo }) {
         <Card.Body>
 
           <Card.Title>Upload photo of house pet</Card.Title>
-          <FileUpload controlId="petPhotos" handleNewFilePaths={handleNewPics} folderPath={folderPath} uploadType="Photo" allowMultipleFiles={true} />    
-          {listingInfo?.petPics && listingInfo.petPics.map((path) => (
-                 <Image height="50px"src={path}/>
+          <FileUpload controlId="petPhotos" handleNewFiles={handleNewPics} folderPath={folderPath} uploadType="Photo" allowMultipleFiles={true} />    
+          {listingInfo?.petPics && listingInfo.petPics.map((pic) => (
+                 <Image height="50px"src={pic.path}/>
               ))}
         </Card.Body>
 

--- a/client/src/components/CPListings/CPRoomSurvey/Step3.js
+++ b/client/src/components/CPListings/CPRoomSurvey/Step3.js
@@ -5,8 +5,10 @@ import FileUpload from '../FileUpload';
 
 export default function Step3({ roomInfo, setRoomInfo }) {
   const folderPath = `users/${roomInfo.LicenseNumber}`;
-	const handleNewPics = (arrNewFilePaths) => {
-		let roomPhotos = roomInfo?.roomPhotos ?? [];
+	const handleNewPics = (arrNewFiles) => {
+    let roomPhotos = roomInfo?.roomPhotos ?? [];
+    //FileUpload component returns an object with a path and name property. The line below converts the array of objects to an array of paths
+    let arrNewFilePaths = arrNewFiles.map(file => file.path);
     roomPhotos.push(...arrNewFilePaths); 
     setRoomInfo({...roomInfo, roomPhotos: roomPhotos});
 	}
@@ -18,7 +20,7 @@ export default function Step3({ roomInfo, setRoomInfo }) {
         <Card.Body>
 
           <Card.Title>Upload photo of room</Card.Title>
-          <FileUpload controlId="roomPhotos" handleNewFilePaths={handleNewPics} folderPath={folderPath} uploadType="Photo" allowMultipleFiles={true} />    
+          <FileUpload controlId="roomPhotos" handleNewFiles={handleNewPics} folderPath={folderPath} uploadType="Photo" allowMultipleFiles={true} />    
           {roomInfo?.roomPhotos && roomInfo.roomPhotos.map((path, i) => (
                  <Image height="50px"src={path} key={i}/>
               ))}

--- a/client/src/components/CPListings/ListingCard.js
+++ b/client/src/components/CPListings/ListingCard.js
@@ -36,10 +36,19 @@ export default function ListingCard({userData, initialListingData}) {
   };
 
   const folderPath = `users/${currentUser.uid}`;
-	const handleNewPics = (arrNewFilePaths) => {
+	
+  const handleNewPics = (arrNewFiles) => {
 		let homePhotos = listingData?.homePhotos ?? [];
+    //FileUpload component returns an object with a path and name property. The line below converts the array of objects to an array of paths
+    let arrNewFilePaths = arrNewFiles.map(file => file.path);
     homePhotos.push(...arrNewFilePaths); 
     handleUpdate({...listingData, homePhotos: homePhotos});
+	}
+
+  const handleNewDocs = (arrNewFiles) => {
+		let homeDocs = listingData?.homeDocs ?? [];
+    homeDocs.push(...arrNewFiles); 
+    handleUpdate({...listingData, homeDocs: homeDocs});
 	}
 
   const gotoHomeSurvey = () => {
@@ -106,7 +115,7 @@ export default function ListingCard({userData, initialListingData}) {
 				1.Exterior front of house. 2. Interior common area. 3. Interior common area.<br/>
 				Upload up to 20 photos. DO NOT POST ROOM PHOTOS here. :)
 			</p>
-			<FileUpload controlId="homePhotos" handleNewFilePaths={handleNewPics} folderPath={folderPath} uploadType="Photo" allowMultipleFiles={true} />    
+			<FileUpload controlId="homePhotos" handleNewFiles={handleNewPics} folderPath={folderPath} uploadType="Photo" allowMultipleFiles={true} />    
           {listingData?.homePhotos && listingData.homePhotos.map((path, i) => (
                  <Image height="50px"src={path} key={i}/>
               ))}
@@ -115,6 +124,14 @@ export default function ListingCard({userData, initialListingData}) {
 		<div>
 			<h4>Complete home survey</h4>
 			<Button onClick={gotoHomeSurvey}>Take survey</Button>
+		</div>
+		<hr/>
+    <div>
+			<h4>Upload facility contract, house rules, and other client facing documents</h4>
+			<FileUpload controlId="homeDocs" handleNewFiles={handleNewDocs} folderPath={folderPath} uploadType="Document" allowMultipleFiles={true} />    
+          {listingData?.homeDocs && listingData.homeDocs.map((file, i) => (
+                 <div><a href={file.path} target="_blank" key={i}>{file.name}</a><br></br></div>
+              ))}
 		</div>
 		<hr/>
 		<div>

--- a/client/src/components/CPListings/Profile.js
+++ b/client/src/components/CPListings/Profile.js
@@ -7,11 +7,11 @@ export default function Profile({ userData, handleUpdate }) {
 	const folderPath = `users/${userData.LicenseNumber}`;
 	const [error, setError] = useState('');
 
-	const handleNewProfilePic = (newFilePath) => {
-		handleUpdate({ profilePicPath: newFilePath[0] });
+	const handleNewProfilePic = (newFile) => {
+		handleUpdate({ profilePicPath: newFile[0]?.path });
 	}
-	const handleNewProfileVid = (newFilePath) => {
-		handleUpdate({ profileVidPath: newFilePath[0] });
+	const handleNewProfileVid = (newFile) => {
+		handleUpdate({ profileVidPath: newFile[0]?.path });
 	}
 
 	const validateLink = (newValue) => {
@@ -40,10 +40,10 @@ export default function Profile({ userData, handleUpdate }) {
 			<Card	>
 				<Card.Body>
 					<Card.Title><h2>Profile</h2></Card.Title>
-					<FileUpload controlId="profilePhotoUpload" handleNewFilePaths={handleNewProfilePic} folderPath={folderPath} uploadLabel="Upload profile photo (Headshot)" uploadType="Photo" />
+					<FileUpload controlId="profilePhotoUpload" handleNewFiles={handleNewProfilePic} folderPath={folderPath} uploadLabel="Upload profile photo (Headshot)" uploadType="Photo" />
 					{userData.profilePicPath && <Image style={{height: '150px'}} src={userData.profilePicPath} />}	
 					<hr />
-					<FileUpload controlId="profileVidUpload" handleNewFilePaths={handleNewProfileVid} uploadLabel="Upload introduction video" uploadType="Video" />
+					<FileUpload controlId="profileVidUpload" handleNewFiles={handleNewProfileVid} uploadLabel="Upload introduction video" uploadType="Video" />
 					{userData.profileVidPath &&
 						<video style={{height: '150px'}} controls>
 							<source src={userData.profileVidPath} />


### PR DESCRIPTION
I changed the fileupload component in listings to store a file object in the database rather than just a file path. This allowed me to store both the path and original name for documents. 

I did not change the format for homePhotos and roomPhotos because they are referenced heavily in Sasha's code.  I do think it would be good to standardize the way we store files/photos in FireBase. Using an object lets us store additional meta data like dateadded and filenames, but means we'd have to update all references to those database fields.

